### PR TITLE
Import for power to work with pyobjc 3

### DIFF
--- a/power/darwin.py
+++ b/power/darwin.py
@@ -9,6 +9,7 @@ __author__ = 'kulakov.ilya@gmail.com'
 import weakref
 import warnings
 import objc
+from objc import super
 from Foundation import *
 from power import common
 


### PR DESCRIPTION
From what I've looked at, it seems that there is an issue with 'super' in python that prevented this from working with pyobjc 3. I filed a bug report [here](https://bitbucket.org/ronaldoussoren/pyobjc/issue/110/subclass-of-nsobject-super-has-no), and this is what they suggested to do. I tested it with pyobjc version 2.5.1 and 3.0.4, and they both seem to work on my mac, version 10.9.5.
