### PR TITLE
Require only the parts of pyobjc that we need.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REQUIREMENTS = []
 
 
 if platform.startswith('darwin'):
-    REQUIREMENTS.append('pyobjc >= 2.5')
+    REQUIREMENTS.append('pyobjc-core >= 2.5')
 
 
 setup(


### PR DESCRIPTION
The pyobjc is large and takes a long time to compile. We only need pyobjc-core.