### PR TITLE
Compute power using voltage and current when power_now file is not available

### DIFF
--- a/power/linux.py
+++ b/power/linux.py
@@ -77,13 +77,19 @@ class PowerManagement(common.PowerManagementBase):
         except IOError:
             energy_full_file = open(os.path.join(supply_path, 'charge_full'), 'r')
 
-        with energy_now_file:
+        try:
             with open(os.path.join(supply_path, 'power_now'), 'r') as power_now_file:
-                with energy_full_file:
-                    energy_now = float(energy_now_file.readline().strip())
                     power_now = float(power_now_file.readline().strip())
-                    energy_full = float(energy_full_file.readline().strip())
-                    return energy_full, energy_now, power_now
+        except IOError:
+            with open(os.path.join(supply_path, 'voltage_now'), 'r') as voltage_now_file:
+                with open(os.path.join(supply_path, 'current_now'), 'r') as current_now_file:
+                        power_now = float(current_now_file.readline().strip()) * float(voltage_now_file.readline().strip()) / 10000000
+
+        with energy_now_file:
+            with energy_full_file:
+                energy_now = float(energy_now_file.readline().strip())
+                energy_full = float(energy_full_file.readline().strip())
+                return energy_full, energy_now, power_now
 
     def get_providing_power_source_type(self):
         """


### PR DESCRIPTION
In my machine (Dell XPS 9560, 4.13.12-1-ARCH), command `tree /sys/class/power_supply/BAT0/` generates:

```
/sys/class/power_supply/BAT0/
├── alarm
├── capacity
├── capacity_level
├── charge_full
├── charge_full_design
├── charge_now
├── current_now
├── cycle_count
├── device -> ../../../PNP0C0A:00
├── manufacturer
├── model_name
├── power
│   ├── async
│   ├── autosuspend_delay_ms
│   ├── control
│   ├── runtime_active_kids
│   ├── runtime_active_time
│   ├── runtime_enabled
│   ├── runtime_status
│   ├── runtime_suspended_time
│   └── runtime_usage
├── present
├── serial_number
├── status
├── subsystem -> ../../../../../../class/power_supply
├── technology
├── type
├── uevent
├── voltage_min_design
└── voltage_now
```

As you can see, there's no `power_now` file.  However, it can be computed from `voltage_now` and `current_now`.  This PR does that for when `power_now` is not available.