### PR TITLE
fixed error about power_on

### DIFF
--- a/power/linux.py
+++ b/power/linux.py
@@ -78,12 +78,22 @@ class PowerManagement(common.PowerManagementBase):
             energy_full_file = open(os.path.join(supply_path, 'charge_full'), 'r')
 
         with energy_now_file:
-            with open(os.path.join(supply_path, 'power_now'), 'r') as power_now_file:
+            try:
+                with open(os.path.join(supply_path, 'power_now'), 'r') as power_now_file:
+                    with energy_full_file:
+                        energy_now = float(energy_now_file.readline().strip())
+                        power_now = float(power_now_file.readline().strip())
+                        energy_full = float(energy_full_file.readline().strip())
+                        return energy_full, energy_now, power_now
+            except IOError:
+                voltage_now_file = open(os.path.join(supply_path, 'voltage_now'), 'r')
+                current_now_file = open(os.path.join(supply_path, 'current_now'), 'r')
                 with energy_full_file:
-                    energy_now = float(energy_now_file.readline().strip())
-                    power_now = float(power_now_file.readline().strip())
-                    energy_full = float(energy_full_file.readline().strip())
-                    return energy_full, energy_now, power_now
+                        energy_now = float(energy_now_file.readline().strip())
+                        power_now = float(voltage_now_file.readline().strip()) * float(current_now_file.readline().strip())
+                        energy_full = float(energy_full_file.readline().strip())
+                        return energy_full, energy_now, power_now
+                    
 
     def get_providing_power_source_type(self):
         """


### PR DESCRIPTION
On my computer,I can not find power_now in `/sys/class/power_supply/BAT0/`
![image](https://user-images.githubusercontent.com/39181969/48199584-76f2f180-e397-11e8-802c-4e3505be0baa.png)
So i use `voltage_now*current_now` to replace it